### PR TITLE
WIP: POM and product version changes for 4.25 release

### DIFF
--- a/bundles/org.eclipse.compare.core/pom.xml
+++ b/bundles/org.eclipse.compare.core/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.compare</groupId>

--- a/bundles/org.eclipse.compare.win32/pom.xml
+++ b/bundles/org.eclipse.compare.win32/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.compare</groupId>

--- a/bundles/org.eclipse.compare/pom.xml
+++ b/bundles/org.eclipse.compare/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.compare</groupId>

--- a/bundles/org.eclipse.core.net.linux/pom.xml
+++ b/bundles/org.eclipse.core.net.linux/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.core</groupId>

--- a/bundles/org.eclipse.core.net.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.core.net.win32.x86_64/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.core</groupId>

--- a/bundles/org.eclipse.core.net.win32/pom.xml
+++ b/bundles/org.eclipse.core.net.win32/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.core</groupId>

--- a/bundles/org.eclipse.core.net/pom.xml
+++ b/bundles/org.eclipse.core.net/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.core</groupId>

--- a/bundles/org.eclipse.jsch.core/pom.xml
+++ b/bundles/org.eclipse.jsch.core/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jsch</groupId>

--- a/bundles/org.eclipse.jsch.ui/pom.xml
+++ b/bundles/org.eclipse.jsch.ui/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.jsch</groupId>

--- a/bundles/org.eclipse.team.core/pom.xml
+++ b/bundles/org.eclipse.team.core/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.team</groupId>

--- a/bundles/org.eclipse.team.genericeditor.diff.extension/pom.xml
+++ b/bundles/org.eclipse.team.genericeditor.diff.extension/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.team</groupId>

--- a/bundles/org.eclipse.team.ui/pom.xml
+++ b/bundles/org.eclipse.team.ui/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.team</groupId>

--- a/bundles/org.eclipse.ui.net/pom.xml
+++ b/bundles/org.eclipse.ui.net/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.ui</groupId>

--- a/examples/org.eclipse.compare.examples.xml/pom.xml
+++ b/examples/org.eclipse.compare.examples.xml/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.compare</groupId>

--- a/examples/org.eclipse.compare.examples/pom.xml
+++ b/examples/org.eclipse.compare.examples/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.compare</groupId>

--- a/examples/org.eclipse.team.examples.filesystem/pom.xml
+++ b/examples/org.eclipse.team.examples.filesystem/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.team</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 

--- a/tests/org.eclipse.compare.tests/pom.xml
+++ b/tests/org.eclipse.compare.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team.tests</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <groupId>org.eclipse.compare</groupId>

--- a/tests/org.eclipse.core.tests.net/pom.xml
+++ b/tests/org.eclipse.core.tests.net/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team.tests</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.core</groupId>
   <artifactId>org.eclipse.core.tests.net</artifactId>

--- a/tests/org.eclipse.jsch.tests/pom.xml
+++ b/tests/org.eclipse.jsch.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team.tests</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jsch</groupId>
   <artifactId>org.eclipse.jsch.tests</artifactId>

--- a/tests/org.eclipse.team.tests.core/pom.xml
+++ b/tests/org.eclipse.team.tests.core/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.team.tests</artifactId>
     <groupId>eclipse.platform.team</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.team</groupId>
   <artifactId>org.eclipse.team.tests.core</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>eclipse.platform.team</groupId>
     <artifactId>eclipse.platform.team</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>eclipse.platform.team.tests</artifactId>


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release