### PR TITLE
Use unified getLineSeparator implementation from resources plug-in

### DIFF
--- a/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.compare; singleton:=true
-Bundle-Version: 3.8.400.qualifier
+Bundle-Version: 3.8.500.qualifier
 Bundle-Activator: org.eclipse.compare.internal.CompareUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.compare/META-INF/MANIFEST.MF
@@ -14,7 +14,7 @@ Export-Package: org.eclipse.compare,
  org.eclipse.compare.patch,
  org.eclipse.compare.structuremergeviewer
 Require-Bundle: org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.core.resources;bundle-version="[3.4.0,4.0.0)",
+ org.eclipse.core.resources;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.jface.text;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.3.0,4.0.0)",
  org.eclipse.ui.views;bundle-version="[3.2.0,4.0.0)",

--- a/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/Patcher.java
+++ b/bundles/org.eclipse.compare/compare/org/eclipse/compare/internal/patch/Patcher.java
@@ -47,17 +47,13 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.resources.IWorkspaceRoot;
-import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.core.runtime.preferences.IScopeContext;
-import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jface.text.TextUtilities;
 
 /**
@@ -366,7 +362,7 @@ public class Patcher implements IHunkFilter {
 		if (!file.exists()) {
 			if (FileBuffers.getTextFileBufferManager().isTextFileLocation(file.getFullPath(), true)) {
 				// For new text files use the line delimiter as defined in the workspace
-				String expectedLD= getLineDelimiterPreference(file);
+				String expectedLD = ResourcesPlugin.getLineSeparator(file);
 				if (expectedLD != null) {
 					String patchLD= TextUtilities.determineLineDelimiter(contents, expectedLD);
 					if (!expectedLD.equals(patchLD))
@@ -384,20 +380,6 @@ public class Patcher implements IHunkFilter {
 		}
 
 		store(bytes,file, pm);
-	}
-
-	private static String getLineDelimiterPreference(IFile file) {
-		IScopeContext[] scopeContext;
-		if (file != null && file.getProject() != null) {
-			// project preference
-			scopeContext= new IScopeContext[] { new ProjectScope(file.getProject()) };
-			String lineDelimiter= Platform.getPreferencesService().getString(Platform.PI_RUNTIME, Platform.PREF_LINE_SEPARATOR, null, scopeContext);
-			if (lineDelimiter != null)
-				return lineDelimiter;
-		}
-		// workspace preference
-		scopeContext= new IScopeContext[] { InstanceScope.INSTANCE };
-		return Platform.getPreferencesService().getString(Platform.PI_RUNTIME, Platform.PREF_LINE_SEPARATOR, null, scopeContext);
 	}
 
 	protected void store(byte[] bytes, IFile file, IProgressMonitor pm) throws CoreException {

--- a/bundles/org.eclipse.compare/pom.xml
+++ b/bundles/org.eclipse.compare/pom.xml
@@ -19,6 +19,6 @@
   </parent>
   <groupId>org.eclipse.compare</groupId>
   <artifactId>org.eclipse.compare</artifactId>
-  <version>3.8.400-SNAPSHOT</version>
+  <version>3.8.500-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Note that the result is slightly different in edge cases (file exists,
file null, no workspace setting) no but now consistent across the
eclipse IDE
