### PR TITLE
Return an empty array for null value in StringUtil

### DIFF
--- a/bundles/org.eclipse.core.net/src/org/eclipse/core/internal/net/StringUtil.java
+++ b/bundles/org.eclipse.core.net/src/org/eclipse/core/internal/net/StringUtil.java
@@ -29,6 +29,9 @@ public class StringUtil {
 	 * @return array of tokens
 	 */
 	public static String[] split(String value, String[] delimiters) {
+		if (value == null) {
+			return new String[0];
+		}
 		ArrayList<String> result = new ArrayList<>();
 		int firstIndex = 0;
 		int separator = 0;


### PR DESCRIPTION
Currently when passing a null value the method simply throws a NPE